### PR TITLE
build: controla paralelismo nos testes

### DIFF
--- a/src/esocial-jt-service/pom.xml
+++ b/src/esocial-jt-service/pom.xml
@@ -27,6 +27,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
+        <fork.count>1</fork.count>
 	</properties>
 
 	<dependencies>
@@ -180,6 +181,15 @@
                 <version>2.4.3</version>
                 <configuration>
                     <encoding>${project.build.sourceEncoding}</encoding>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.0</version>
+                <configuration>
+                    <forkCount>${fork.count}</forkCount>
+                    <reuseForks>true</reuseForks>
+                    <!--<rerunFailingTestsCount>2</rerunFailingTestsCount>-->
                 </configuration>
             </plugin>
 		</plugins>


### PR DESCRIPTION
No momento, há uma race condition na execução dos testes, pois todos
usam o mesmo banco em memória. Agora é possível controlar o paralelismo.
Isto serve apenas como uma solução de contorno.

Issue: #10