### PR TITLE
Permitir transmissor diferente do CNPJ do empregador

### DIFF
--- a/src/esocial-jt-service/src/main/java/br/jus/tst/esocialjt/EsocialApplication.java
+++ b/src/esocial-jt-service/src/main/java/br/jus/tst/esocialjt/EsocialApplication.java
@@ -6,11 +6,20 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
+
 @SpringBootApplication
-public class EsocialApplication {
+public class EsocialApplication extends SpringBootServletInitializer  {
 
 	public static void main(String[] args) {
 		SpringApplication.run(EsocialApplication.class, args);
+	}
+	
+	@Override
+	protected SpringApplicationBuilder configure(SpringApplicationBuilder builder) {
+ 
+		return builder.sources(EsocialApplication.class);
 	}
 	
 	@Bean

--- a/src/esocial-jt-service/src/main/java/br/jus/tst/esocialjt/xml/GeradorLote.java
+++ b/src/esocial-jt-service/src/main/java/br/jus/tst/esocialjt/xml/GeradorLote.java
@@ -35,6 +35,12 @@ public class GeradorLote {
 	@Value("${esocialjt.limite-eventos-por-lote: 50}")
 	private Long LIMITE_EVENTOS_LOTE;
 	
+	@Value("${esocialjt.tpInscIdeTransmissor:0}")
+	private String tpInscIdeTransmissor;
+ 
+	@Value("${esocialjt.nrInscIdeTransmissor:0}")
+	private String nrInscIdeTransmissor;
+	
 	public String gerarXmlLote(Lote lote) throws GeracaoXmlException {
 		List<EnvioEvento> enviosEvento = lote.getEnviosEvento();
 		
@@ -88,9 +94,17 @@ public class GeradorLote {
 	}
 
 	private TIdeTransmissor gerarTransmissor(String cnpj) {
+
 		TIdeTransmissor transmissor = new TIdeTransmissor();
-		transmissor.setNrInsc(cnpj);
-		transmissor.setTpInsc((byte) 1);
+
+		if (!"0".equals(tpInscIdeTransmissor.trim()) && !"0".equals(nrInscIdeTransmissor.trim())) {
+			transmissor.setNrInsc(nrInscIdeTransmissor.trim());
+			transmissor.setTpInsc((byte) Integer.parseInt(tpInscIdeTransmissor.trim()));
+		} else {
+			transmissor.setNrInsc(cnpj);
+			transmissor.setTpInsc((byte) 1);
+		}
+
 		return transmissor;
 	}
 

--- a/src/esocial-jt-service/src/main/resources/application.properties
+++ b/src/esocial-jt-service/src/main/resources/application.properties
@@ -1,6 +1,10 @@
 #Web
 server.servlet.contextPath=/esocial-jt-service
 
+#preencha caso o certificado do transmisssor seja diferente do empregador a ser cadastrado no evento S1000. Ou seja, será usado um certificado de uma Pessoa Física para envio dos eventos.
+#esocialjt.tpInscIdeTransmissor=2
+#esocialjt.nrInscIdeTransmissor= cpf do transmisssor
+
 #eSocial-JT
 esocialjt.cnpj-empregador=00509968000148
 esocialjt.ambiente=PRODUCAO_RESTRITA


### PR DESCRIPTION
Permitir transmissor diferente do CNPJ do empregador. Dessa forma, pode-se um certificado de uma pessoa física que recebeu a delegação para enviar informações para o eSocial para um determinado empregador.