### PR TITLE
Permitir transmissor diferente do empregador e  Disponibilizar aplicação com arquivo war para servidor não Embedded

### DIFF
--- a/src/esocial-jt-service/README.md
+++ b/src/esocial-jt-service/README.md
@@ -80,6 +80,16 @@ Verifique se a aplicação está no ar acessando a url
 http://localhost:8080/esocial-jt-service/actuator/health
 ```
 
+#### Geração de war
+
+Alternativamente, é possível gerar um `.war` que pode ser implantado no servidor de aplicação, utilizando o profile **war**.
+
+```bash
+cd src
+mvn clean package -P war
+```
+
+
 ### Testando o primeiro envio
 
 O **esocial-jt-service** foi projetado para receber dados de ocorrência via JSON a partir dos sistemas de origem ou de um conector. Porém, para um primeiro teste, no ambiente de [Produção Restrita](http://portal.esocial.gov.br/institucional/ambiente-de-producao-restrita), é possível enviar manualmente dados para o **esocial-jt-service**. Para isso, faça uma cópia do arquivo [/src/main/resources/exemplos/informacoes_empregador.json](./src/main/resources/exemplos/informacoes_empregador.json), edite com as informações referentes à instituição (o CNPJ deve ser o mesmo do proprietário do Certificado Digital) e envia usando o método **POST** (via linha de comando ou [Postman](https://www.getpostman.com/)) para o _endpoint_:

--- a/src/esocial-jt-service/pom.xml
+++ b/src/esocial-jt-service/pom.xml
@@ -6,7 +6,7 @@
 	<groupId>br.jus.tst</groupId>
 	<artifactId>esocial-jt-service</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
-	<packaging>jar</packaging>
+	<packaging>${project.packaging}</packaging>
 
 	<name>esocial-jt-service</name>
 	<description>Web service que provê funcionalidades de envios de eventos para o eSocial</description>
@@ -30,11 +30,29 @@
 		<fork.count>1</fork.count>
 	</properties>
 
-	<dependencies>
+	<profiles>
+		<profile>
+			<id>jar</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+			<properties>
+				<project.packaging>jar</project.packaging>
+			</properties>
+		</profile>
+		<profile>
+			<id>war</id>
+			<properties>
+				<project.packaging>war</project.packaging>
+			</properties>					
+		</profile>
+	</profiles>
+
+	<dependencies>		 
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
-		</dependency>
+		</dependency> 		
 		<dependency>
 			<groupId>org.mapstruct</groupId>
 			<artifactId>mapstruct-jdk8</artifactId>

--- a/src/esocial-jt-service/src/main/java/br/jus/tst/esocialjt/EsocialApplication.java
+++ b/src/esocial-jt-service/src/main/java/br/jus/tst/esocialjt/EsocialApplication.java
@@ -6,11 +6,20 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
+
 @SpringBootApplication
-public class EsocialApplication {
+public class EsocialApplication extends SpringBootServletInitializer  {
 
 	public static void main(String[] args) {
 		SpringApplication.run(EsocialApplication.class, args);
+	}
+	
+	@Override
+	protected SpringApplicationBuilder configure(SpringApplicationBuilder builder) {
+ 
+		return builder.sources(EsocialApplication.class);
 	}
 	
 	@Bean

--- a/src/esocial-jt-service/src/main/java/br/jus/tst/esocialjt/comunicacaogov/RetornoProcessamentoUtil.java
+++ b/src/esocial-jt-service/src/main/java/br/jus/tst/esocialjt/comunicacaogov/RetornoProcessamentoUtil.java
@@ -1,8 +1,7 @@
 package br.jus.tst.esocialjt.comunicacaogov;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
+import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -16,6 +15,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import br.jus.esocialjt.comunicacao.retorno.processamento.ESocial;
@@ -49,9 +49,9 @@ public class RetornoProcessamentoUtil {
 
 		DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
 		try {
-			DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
-			InputStream is = new ByteArrayInputStream(xmlRetorno.getBytes());
-			Document doc = dBuilder.parse(is);
+			
+			DocumentBuilder docBuilder = dbFactory.newDocumentBuilder(); 
+			Document doc = docBuilder.parse(new InputSource(new StringReader(xmlRetorno))); 
 			
 			NodeList nodeList = doc.getElementsByTagName("tot");
 			for (int i = 0; i < nodeList.getLength(); i++) {

--- a/src/esocial-jt-service/src/main/java/br/jus/tst/esocialjt/xml/GeradorLote.java
+++ b/src/esocial-jt-service/src/main/java/br/jus/tst/esocialjt/xml/GeradorLote.java
@@ -35,6 +35,12 @@ public class GeradorLote {
 	@Value("${esocialjt.limite-eventos-por-lote: 50}")
 	private Long LIMITE_EVENTOS_LOTE;
 	
+	@Value("${esocialjt.tpInscIdeTransmissor:0}")
+	private String tpInscIdeTransmissor;
+ 
+	@Value("${esocialjt.nrInscIdeTransmissor:0}")
+	private String nrInscIdeTransmissor;
+	
 	public String gerarXmlLote(Lote lote) throws GeracaoXmlException {
 		List<EnvioEvento> enviosEvento = lote.getEnviosEvento();
 		
@@ -88,9 +94,17 @@ public class GeradorLote {
 	}
 
 	private TIdeTransmissor gerarTransmissor(String cnpj) {
+
 		TIdeTransmissor transmissor = new TIdeTransmissor();
-		transmissor.setNrInsc(cnpj);
-		transmissor.setTpInsc((byte) 1);
+
+		if (!"0".equals(tpInscIdeTransmissor.trim()) && !"0".equals(nrInscIdeTransmissor.trim())) {
+			transmissor.setNrInsc(nrInscIdeTransmissor.trim());
+			transmissor.setTpInsc((byte) Integer.parseInt(tpInscIdeTransmissor.trim()));
+		} else {
+			transmissor.setNrInsc(cnpj);
+			transmissor.setTpInsc((byte) 1);
+		}
+
 		return transmissor;
 	}
 

--- a/src/esocial-jt-service/src/main/resources/application.properties
+++ b/src/esocial-jt-service/src/main/resources/application.properties
@@ -1,6 +1,10 @@
 #Web
 server.servlet.contextPath=/esocial-jt-service
 
+#preencha caso o certificado do transmisssor seja diferente do empregador a ser cadastrado no evento S1000. Ou seja, será usado um certificado de uma Pessoa Física para envio dos eventos.
+#esocialjt.tpInscIdeTransmissor=2
+#esocialjt.nrInscIdeTransmissor= cpf do transmisssor
+
 #eSocial-JT
 esocialjt.cnpj-empregador=00509968000148
 esocialjt.ambiente=PRODUCAO_RESTRITA

--- a/src/esocial-jt-service/src/main/resources/db/migration/V1__create_initial_structure.sql
+++ b/src/esocial-jt-service/src/main/resources/db/migration/V1__create_initial_structure.sql
@@ -117,7 +117,7 @@ create index EST_EVENTO_FK03 on EST_EVENTO (COD_TIPO);
 
 alter table EST_TIPO add constraint EST_TIPO_FK01 foreign key (COD_GRUPO_TIPO)
     references EST_GRUPO_TIPO_EVENTO (COD_GRUPO_TIPO);
-create index EST_TIPO_FK01 on EST_GRUPO_TIPO_EVENTO (COD_GRUPO_TIPO);  
+create index EST_TIPO_FK01 on EST_TIPO (COD_GRUPO_TIPO); 
 
 alter table EST_LOTE add constraint EST_LOTE_FK01 foreign key (COD_ESTADO)
     references EST_ESTADO (COD_ESTADO);


### PR DESCRIPTION
- Permitir transmissor diferente do CNPJ do empregador.
com essa alteração, será possível enviar eventos com certificado de terceiros que possuam delegação para isso.

- Disponibilizar aplicação com arquivo war para servidor não Embedded.
 com essa alteração ao empacotar aplicação para um arquivo war, será possível iniciar os serviços e componentes em um servidor  não Embedded.