### PR TITLE
Acrescenta zeros à direita em caso de nrInsc representar raiz do CNPJ

### DIFF
--- a/src/esocial-jt-service/src/main/java/br/jus/tst/esocialjt/xml/GeradorId.java
+++ b/src/esocial-jt-service/src/main/java/br/jus/tst/esocialjt/xml/GeradorId.java
@@ -13,11 +13,15 @@ public class GeradorId {
 	
 	@Autowired
 	private Sequencial sequencial;
-
-	public String gerarId(String cnpj) {
+        
+        public String gerarId(String cnpj) {
 		LocalDateTime date = LocalDateTime.now();
 		String seq = String.format("%05d", sequencial.proximo());
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+                
+                //caso seja o CNPJ base acrescenta zeros para completar o tamanho
+                if (cnpj.length() == 8) cnpj = cnpj + "000000";
+        
 		return "ID1" + cnpj + date.format(formatter).replace("+", "") + seq;
 	}
 

--- a/src/esocial-jt-service/src/test/java/br/jus/tst/esocialjt/xml/GeradorIdTest.java
+++ b/src/esocial-jt-service/src/test/java/br/jus/tst/esocialjt/xml/GeradorIdTest.java
@@ -44,5 +44,19 @@ public class GeradorIdTest {
 		long diferencaTempo = Math.abs(tempoGeracao-tempoAgora);
 		return diferencaTempo;
 	}
+        
+        @Test
+	public void verificarGeracaoDoIdCNPJRaiz() throws ParseException {
+
+                String cnpjRaiz = CNPJ.substring(0,8);
+                
+		String id = geradorId.gerarId(cnpjRaiz);
+		SoftAssertions soft = new SoftAssertions();
+		soft.assertThat(id.substring(0, 3)).isEqualTo("ID1");
+		soft.assertThat(id.substring(3, 11)).isEqualTo(cnpjRaiz);
+                soft.assertThat(id.substring(11, 17)).isEqualTo("000000");
+		soft.assertAll();
+                
+	}
 
 }


### PR DESCRIPTION
Este procedimento é necessário para atender a validação da regra "REGRA_VALIDA_ID_EVENTO"

A identificação única do evento (Id) é composta por 36 caracteres, conforme o que segue:
IDTNNNNNNNNNNNNNNAAAAMMDDHHMMSSQQQQQ
ID - Texto Fixo "ID";
T - Tipo de Inscrição do Empregador (1 - CNPJ; 2 - CPF);
NNNNNNNNNNNNNN - Número do CNPJ ou CPF do empregador - Completar com
zeros à direita. No caso de pessoas jurídicas, o CNPJ informado deve conter 8 ou 14
posições de acordo com o enquadramento do contribuinte para preenchimento do campo
{ideEmpregador/nrInsc} do evento S-1000, completando-se com zeros à direita, se
necessário.
AAAAMMDD - Ano, mês e dia da geração do evento;
HHMMSS - Hora, minuto e segundo da geração do evento;
QQQQQ - Número sequencial da chave. Incrementar somente quando ocorrer geração de
eventos na mesma data/hora, completando com zeros à esquerda.
OBS.: No caso de pessoas jurídicas, o CNPJ informado deverá conter 8 ou 14 posições de
acordo com o enquadramento do contribuinte para preenchimento do campo
{ideEmpregador/nrInsc} do evento S-1000, completando-se com zeros à direita, se
necessário.
