### PR TITLE
Incluir o nome da rede para conexão de

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,4 +38,5 @@ services:
 
 networks:
   esocial-net:
+    name: esocial-net
     driver: bridge


### PR DESCRIPTION
Olá, pessoal! Tudo bem?
Sou desenvolvedor do TJDFT e precisava que atualizem o nome da rede para que podemos ter um outros containers de um outro docker-compose possa conectar a essa rede "esocial-net". Seria possível incluir no master?

Obrigado!!