### PR TITLE
fix: Corrige erro 403 Forbidden em chamadas Post quando keycloak.enab…

### DIFF
--- a/src/esocial-jt-service/src/main/java/br/jus/tst/esocialjt/SecurityConfigDisable.java
+++ b/src/esocial-jt-service/src/main/java/br/jus/tst/esocialjt/SecurityConfigDisable.java
@@ -10,7 +10,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 public class SecurityConfigDisable extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity httpSecurity) throws Exception {
-        httpSecurity
+        httpSecurity.cors().and().csrf().disable()
                 .authorizeRequests()
                 .antMatchers("/")
                 .permitAll();


### PR DESCRIPTION
…led=false

Cenário: Devido a cors e csrf estarem habilitados, chamadas HTTP POST retornam erro 403 quando keycloak.enabled=false e SecurityConfigDisable é utilizado. Chamdas GET funcionam normalmente.

Solução: Esse fix adiciona a mesma configuração da classe SecurityConfig para desabilitar cors e csrf, eliminando assim erros em chamadas POST.

fix: #374