### PR TITLE
Corrigir erro de refresh_token=undefined

### DIFF
--- a/frontend/src/shared/keycloak.js
+++ b/frontend/src/shared/keycloak.js
@@ -24,12 +24,13 @@ export function initKeycloak() {
 
   return keycloak
     .init({
-      onLoad: "login-required"
+      onLoad: "login-required",
+      checkLoginIframe: false
     })
     .then((authenticated) => {
       if (!authenticated) {
-        console.warn(`Não autenticado!`);
-        login();
+        console.warn("Usuário não autenticado! Redirecionando...");
+        keycloak.login();
       }
     })
     .catch((err) => {

--- a/frontend/src/shared/keycloak.js
+++ b/frontend/src/shared/keycloak.js
@@ -31,10 +31,11 @@ export function initKeycloak() {
       if (!authenticated) {
         console.warn("Usuário não autenticado! Redirecionando...");
         keycloak.login();
+      } else {
+        console.log("Usuário autenticado com sucesso!");        
       }
     })
     .catch((err) => {
-      console.error("Falha ao iniciar o keycloak: ", err);
-      throw err;
+      console.error("Erro ao iniciar Keycloak:", err);
     });
 }


### PR DESCRIPTION
Atualmente, ao tentar atualizar o token no Keycloak, a requisição está sendo enviada com refresh_token=undefined, resultando em um erro 400 Bad Request.

O refresh_token pode não estar disponível no momento da atualização. A aplicação tenta atualizar o token mesmo quando ele não existe, gerando falhas na autenticação.