### PR TITLE
Atualização de versão keycloak-js e correções no frontend

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "@testing-library/react": "^12.1.2",
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.6.0",
-    "keycloak-js": "^16.1.1",
+    "keycloak-js": "^26.2.0",
     "muibox": "^2.0.0",
     "notistack": "^2.0.3",
     "prop-types": "^15.8.1",
@@ -41,7 +41,10 @@
   "jest": {
     "moduleNameMapper": {
       "axios": "axios/dist/node/axios.cjs"
-    }
+    },
+    "transformIgnorePatterns": [
+      "node_modules/(?!(keycloak-js)/)"
+    ]
   },
   "browserslist": {
     "production": [

--- a/frontend/src/app/App.test.js
+++ b/frontend/src/app/App.test.js
@@ -10,3 +10,11 @@ test("renders without crashing", () => {
     </QueryClientProvider>
   );
 });
+
+jest.mock('keycloak-js', () => {
+  return jest.fn().mockImplementation(() => ({
+    init: jest.fn(),
+    login: jest.fn(),
+    logout: jest.fn(),
+  }));
+});

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -3,3 +3,6 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+// Mockar window.scrollTo
+global.scrollTo = jest.fn();

--- a/frontend/src/shared/env.js
+++ b/frontend/src/shared/env.js
@@ -7,9 +7,12 @@ export const ESOCIAL_JT_SERVICE_URL = getEnv(
   "ESOCIAL_JT_SERVICE_URL",
   "http://localhost:8080/esocial-jt-service/"
 );
-export const KEYCLOAK_URL = getEnv("KEYCLOAK_URL", "");
-export const KEYCLOAK_REALM = getEnv("KEYCLOAK_REALM", "");
-export const KEYCLOAK_CLIENT_ID = getEnv("KEYCLOAK_CLIENT_ID", "");
+export const KEYCLOAK_URL = getEnv(
+  "KEYCLOAK_URL",
+  "http://localhost:9090/auth"
+);
+export const KEYCLOAK_REALM = getEnv("KEYCLOAK_REALM", "app-realm");
+export const KEYCLOAK_CLIENT_ID = getEnv("KEYCLOAK_CLIENT_ID", "esocial-app");
 
 function getEnv(envName, defaultValue) {
   if (!window.env) {

--- a/frontend/src/shared/keycloak.js
+++ b/frontend/src/shared/keycloak.js
@@ -24,7 +24,8 @@ export function initKeycloak() {
 
   return keycloak
     .init({
-      onLoad: "login-required"
+      onLoad: "check-sso",
+      checkLoginIframe: false
     })
     .then((authenticated) => {
       if (!authenticated) {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3124,11 +3124,6 @@ base16@^1.0.0:
   resolved "https://registry.npmjs.org/base16/-/base16-1.0.0.tgz#e297f60d7ec1014a7a971a39ebc8a98c0b681e70"
   integrity sha512-pNdYkNPiJUnEhnfXV56+sQy8+AaPcG3POZAUnwr4EeqCUZFz4u2PePbo3e5Gj4ziYPCWGUZT9RHisvJKnwFuBQ==
 
-base64-js@1.3.1:
-  version "1.3.1"
-  resolved "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
-  integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
-
 batch@0.6.1:
   version "0.6.1"
   resolved "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
@@ -6112,11 +6107,6 @@ jest@^27.4.3:
     import-local "^3.0.2"
     jest-cli "^27.5.1"
 
-js-sha256@0.9.0:
-  version "0.9.0"
-  resolved "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz#0b89ac166583e91ef9123644bd3c5334ce9d0966"
-  integrity sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==
-
 js-sha3@0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
@@ -6244,13 +6234,10 @@ jsonpointer@^5.0.0:
     array-includes "^3.1.4"
     object.assign "^4.1.2"
 
-keycloak-js@^16.1.1:
-  version "16.1.1"
-  resolved "https://registry.npmjs.org/keycloak-js/-/keycloak-js-16.1.1.tgz#e235f212cc336b9752863ebdce7f7a5707b11b8a"
-  integrity sha512-AkRNIJFSMLfQKIBKK31UL4FGI59MQFf68Bf8I+PFbOSKNtnfGVPYLiZeJgy03Kv5ddswHBjVZOY5T0f5RpZpLw==
-  dependencies:
-    base64-js "1.3.1"
-    js-sha256 "0.9.0"
+keycloak-js@^26.2.0:
+  version "26.2.0"
+  resolved "https://registry.yarnpkg.com/keycloak-js/-/keycloak-js-26.2.0.tgz#0924feec13a014563b2e041e255657c24c145714"
+  integrity sha512-CrFcXTN+d6J0V/1v3Zpioys6qHNWE6yUzVVIsCUAmFn9H14GZ0vuYod+lt+SSpMgWGPuneDZBSGBAeLBFuqjsw==
 
 kind-of@^6.0.2:
   version "6.0.3"


### PR DESCRIPTION
@pablorobert e @tiagoben , blz?

Não sei se vocês atualizaram a versão do Keycloak do TST, mas tem um bug onde, apartir das versões 18+, o Keycloak mudou a forma no tratamento de callback de redirecionamento por questões de segurança. 

Com essa atualização do Keycloak no TJDFT, houve um problema de redirecionamento infinito entre o keycloak (campo redirect_urls) e o frontend no browser que a aplicação não soube tratar.

Criei esse PR para analisar e mergear para o branch principal!

Obs.: Precisei mudar alguns testes na aplicação, conforme esse PR.